### PR TITLE
Scrap support for depth 1 searches

### DIFF
--- a/src/components/Game/Game.spec.tsx
+++ b/src/components/Game/Game.spec.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 
 import Game from './Game'
 import type { GameProps } from './Game'
-import { Hatetris0 } from '../../enemy-ais/hatetris-ai'
+import { HatetrisAi } from '../../enemy-ais/hatetris-ai'
 import hatetrisRotationSystem from '../../rotation-systems/hatetris-rotation-system'
 
 jest.useFakeTimers()
@@ -17,7 +17,7 @@ describe('<Game>', () => {
     return shallow<Game>(
       <Game
         bar={4}
-        EnemyAi={Hatetris0}
+        EnemyAi={HatetrisAi}
         replayTimeout={0}
         rotationSystem={hatetrisRotationSystem}
         wellDepth={20}

--- a/src/enemy-ais/hatetris-ai.spec.tsx
+++ b/src/enemy-ais/hatetris-ai.spec.tsx
@@ -6,7 +6,7 @@ import { shallow } from 'enzyme'
 import * as React from 'react'
 
 import Game from '../components/Game/Game'
-import { Hatetris0, Hatetris1 } from './hatetris-ai'
+import { HatetrisAi } from './hatetris-ai'
 import hatetrisRotationSystem from '../rotation-systems/hatetris-rotation-system'
 
 // Note: well bits are flipped compared to what you would see on the screen.
@@ -14,155 +14,139 @@ import hatetrisRotationSystem from '../rotation-systems/hatetris-rotation-system
 // *right* of each binary numeric literal
 
 describe('HatetrisAi', () => {
-  describe('Hatetris0', () => {
-    const game = shallow<Game>(
-      <Game
-        bar={4}
-        EnemyAi={Hatetris0}
-        replayTimeout={0}
-        rotationSystem={hatetrisRotationSystem}
-        wellDepth={8}
-        wellWidth={10}
-      />
-    )
+  const game = shallow<Game>(
+    <Game
+      bar={4}
+      EnemyAi={HatetrisAi}
+      replayTimeout={0}
+      rotationSystem={hatetrisRotationSystem}
+      wellDepth={8}
+      wellWidth={10}
+    />
+  )
 
-    const hatetris0 = game.state().enemyAi
+  const hatetris = game.state().enemyAi
 
-    it('generates an S by default', () => {
-      expect(hatetris0([
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000
-      ])).toBe(0) // S
-    })
-
-    it('generates a Z when an S would result in a lower stack', () => {
-      expect(hatetris0([
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0001000000,
-        0b1111011111
-      ])).toBe(1) // Z
-    })
-
-    it('generates an O when an S or Z would result in a lower stack', () => {
-      expect(hatetris0([
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b1111101111
-      ])).toBe(2) // O
-    })
-
-    it('generates an I when an S, Z or O would result in a lower stack', () => {
-      expect(hatetris0([
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b1111001111
-      ])).toBe(3) // I
-    })
-
-    it('generates an L when an S, Z, O or I would result in a lower stack', () => {
-      expect(hatetris0([
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b1111100111,
-        0b1011100111,
-        0b1111110111
-      ])).toBe(4) // L
-    })
-
-    it('generates a J when an S, Z, O, I or L would result in a lower stack', () => {
-      expect(hatetris0([
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b1111100111,
-        0b1011100111,
-        0b1111101111
-      ])).toBe(5) // J
-    })
-
-    it('generates a T when an S, Z, O, I, L or J would result in a lower stack', () => {
-      expect(hatetris0([
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b1000000000,
-        0b1111000011,
-        0b1111100111
-      ])).toBe(6) // T
-    })
-
-    // Only while writing these unit tests did I discover this subtle piece of
-    // behaviour. The HATETRIS AI doesn't track *lines made*, it tracks *stack
-    // height*. In this situation, L, J and T would all result in a stack
-    // reaching y = 6. L comes first so it is selected. This happens even though
-    // L and J *give you a line* while T would not.
-    it('just gives you a line sometimes!', () => {
-      expect(hatetris0([
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b1111000011,
-        0b1111100111
-      ])).toBe(4) // L
-    })
+  it('generates an S by default', () => {
+    expect(hatetris([
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000
+    ])).toBe(0) // S
   })
 
-  describe('Hatetris1', () => {
-    const game = shallow<Game>(
-      <Game
-        bar={4}
-        EnemyAi={Hatetris1}
-        replayTimeout={0}
-        rotationSystem={hatetrisRotationSystem}
-        wellDepth={8}
-        wellWidth={10}
-      />
-    )
+  it('generates a Z when an S would result in a lower stack', () => {
+    expect(hatetris([
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0001000000,
+      0b1111011111
+    ])).toBe(1) // Z
+  })
 
-    const hatetris1 = game.state().enemyAi
+  it('generates an O when an S or Z would result in a lower stack', () => {
+    expect(hatetris([
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b1111101111
+    ])).toBe(2) // O
+  })
 
-    it('picks a different piece in some situations', () => {
-      expect(hatetris1([
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b0000000000,
-        0b1111000011,
-        0b1111100111
-      ])).toBe(6) // T (followed by O, resulting in stack reaching y = 4)
-    })
+  it('generates an I when an S, Z or O would result in a lower stack', () => {
+    expect(hatetris([
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b1111001111
+    ])).toBe(3) // I
+  })
+
+  it('generates an L when an S, Z, O or I would result in a lower stack', () => {
+    expect(hatetris([
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b1111100111,
+      0b1011100111,
+      0b1111110111
+    ])).toBe(4) // L
+  })
+
+  it('generates a J when an S, Z, O, I or L would result in a lower stack', () => {
+    expect(hatetris([
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b1111100111,
+      0b1011100111,
+      0b1111101111
+    ])).toBe(5) // J
+  })
+
+  it('generates a T when an S, Z, O, I, L or J would result in a lower stack', () => {
+    expect(hatetris([
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b1000000000,
+      0b1111000011,
+      0b1111100111
+    ])).toBe(6) // T
+  })
+
+  // Only while writing these unit tests did I discover this subtle piece of
+  // behaviour. The HATETRIS AI doesn't track *lines made*, it tracks *stack
+  // height*. In this situation, L, J and T would all result in a stack
+  // reaching y = 6. L comes first so it is selected. This happens even though
+  // L and J *give you a line* while T would not.
+  it('just gives you a line sometimes!', () => {
+    expect(hatetris([
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b1111000011,
+      0b1111100111
+    ])).toBe(4) // L
+  })
+
+  // Coverage...
+  it('generates an S when say an I would clear the board', () => {
+    expect(hatetris([
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b1111111110,
+      0b1111111110,
+      0b1111111110,
+      0b1111111110
+    ])).toBe(0) // S
   })
 })

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,14 +9,14 @@ import * as ReactDOM from 'react-dom'
 
 import './index.css'
 import Game from './components/Game/Game'
-import { Hatetris0 } from './enemy-ais/hatetris-ai'
+import { HatetrisAi } from './enemy-ais/hatetris-ai'
 import hatetrisRotationSystem from './rotation-systems/hatetris-rotation-system'
 
 ReactDOM.render(
   (
     <Game
       bar={4}
-      EnemyAi={Hatetris0}
+      EnemyAi={HatetrisAi}
       replayTimeout={50}
       rotationSystem={hatetrisRotationSystem}
       wellDepth={20}


### PR DESCRIPTION
Simplify the HATETRIS AI to no longer support the (completely unused) option where it searches to depth 1 instead of depth 0. This enables the code to be greatly simplified.