### PR TITLE
Live dev server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ cache:
 script:
   - npm run test
   - npm run build
-  - npm run test-built
+  - npm run cypress-built

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -1,0 +1,22 @@
+const webpack = require('webpack')
+
+const webpackConfigProd = require('./webpack.config.prod')
+
+module.exports = {
+  ...webpackConfigProd,
+  mode: 'development',
+
+  // "Recommended choice for development builds with high quality SourceMaps"
+  devtool: 'eval-source-map',
+
+  entry: [
+    'webpack-hot-middleware/client',
+    ...webpackConfigProd.entry
+  ],
+
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new webpack.NoEmitOnErrorsPlugin(),
+    ...webpackConfigProd.plugins
+  ]
+}

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -2,8 +2,14 @@ const HtmlWebpackPlugin = require('html-webpack-plugin')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 module.exports = {
-  mode: 'development',
-  entry: './src/index.tsx',
+  mode: 'production',
+
+  // "Recommended choice for production builds with high quality SourceMaps"
+  devtool: 'source-map',
+
+  entry: [
+    './src/index.tsx'
+  ],
   plugins: [
     new MiniCssExtractPlugin({
       filename: 'bundle.css'

--- a/cypress/integration/test-built.js
+++ b/cypress/integration/test-built.js
@@ -2,7 +2,7 @@
 
 describe('HATETRIS', () => {
   it('plays a game', () => {
-    cy.visit('http://localhost:3000/dist/hatetris.html')
+    cy.visit('http://localhost:3000/hatetris.html')
     cy.contains('You\'re playing HATETRIS by qntm')
 
     cy.get('button').contains('start new game').click()
@@ -19,7 +19,7 @@ describe('HATETRIS', () => {
   it('plays a Base2048 replay', () => {
     const replay = 'ϥقໂɝƐඖДݹஶʈງƷ௨ೲໃܤѢقҾחࢲටฅڗ௨ΡІݪ௨ళȣݹࢴටງ໒௨ஶໃܥ௨റІݮ௨ఴІݥذඡଈݹƍق๓অஒॴแђञඖЅи௨sǶɔۑడПݷޠقԩݹࠉൿຟɓతණງஈশ੬෪অࠑථධٽଫ൝ଆࡨশ૫СܭߜయլݚɶऋഭܭرɤธӃస൯'
 
-    cy.visit('http://localhost:3000/dist/hatetris.html', {
+    cy.visit('http://localhost:3000/hatetris.html', {
       onBeforeLoad: window => {
         cy.stub(window, 'prompt').returns(replay)
       }

--- a/cypress/server.js
+++ b/cypress/server.js
@@ -1,6 +1,0 @@
-const express = require('express')
-const app = express()
-app.use(express.static('.'))
-app.listen(3000, () => {
-  console.log('listening')
-})

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
   "main": "index.js",
   "scripts": {
     "build": "webpack --config ./config/webpack.config.prod.js",
+    "cypress": "start-server-and-test \"npm run start\" http://localhost:3000/hatetris.html \"cypress run\"",
+    "cypress-built": "start-server-and-test \"npm run start-built\" http://localhost:3000/hatetris.html \"cypress run\"",
     "eslint": "eslint src --ext .ts,.tsx",
     "jest": "jest",
     "pretest": "npm run eslint",
     "start": "node scripts/start.js",
     "start-built": "node scripts/start-built.js",
-    "test": "npm run jest",
-    "test-built": "start-server-and-test \"npm run start-built\" http://localhost:3000/dist/hatetris.html \"cypress run\""
+    "test": "npm run jest"
   },
   "keywords": [
     "tetris"

--- a/package.json
+++ b/package.json
@@ -9,10 +9,14 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "webpack",
-    "pretest": "eslint src --ext .ts,.tsx",
-    "test": "jest",
-    "test-built": "start-server-and-test \"node cypress/server.js\" http://localhost:3000/dist/hatetris.html \"cypress run\""
+    "build": "webpack --config ./config/webpack.config.prod.js",
+    "eslint": "eslint src --ext .ts,.tsx",
+    "jest": "jest",
+    "pretest": "npm run eslint",
+    "start": "node scripts/start.js",
+    "start-built": "node scripts/start-built.js",
+    "test": "npm run jest",
+    "test-built": "start-server-and-test \"npm run start-built\" http://localhost:3000/dist/hatetris.html \"cypress run\""
   },
   "keywords": [
     "tetris"
@@ -56,11 +60,14 @@
     "jest": "^26.4.2",
     "mini-css-extract-plugin": "^1.0.0",
     "react": "^16.13.1",
+    "react-dev-utils": "^11.0.4",
     "react-dom": "^16.13.1",
     "start-server-and-test": "^1.11.3",
     "ts-loader": "^9.1.1",
     "typescript": "^4.0.3",
     "webpack": "^5.2.0",
-    "webpack-cli": "^4.0.0"
+    "webpack-cli": "^4.0.0",
+    "webpack-dev-middleware": "^4.1.0",
+    "webpack-hot-middleware": "^2.25.0"
   }
 }

--- a/scripts/start-built.js
+++ b/scripts/start-built.js
@@ -1,0 +1,8 @@
+const express = require('express')
+
+express()
+  .use(express.static('./dist'))
+  .listen(3000, () => {
+    console.log('listening')
+    console.log('http://localhost:3000/hatetris.html')
+  })

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,6 +1,5 @@
 const express = require('express')
 const WebpackDevServerUtils = require('react-dev-utils/WebpackDevServerUtils')
-const openBrowser = require('react-dev-utils/openBrowser')
 const webpack = require('webpack')
 const WebpackDevMiddleware = require('webpack-dev-middleware')
 const WebpackHotMiddleware = require('webpack-hot-middleware')
@@ -19,5 +18,5 @@ express()
   .use(WebpackHotMiddleware(compiler))
   .listen(3000, () => {
     console.log('listening')
-    openBrowser('http://localhost:3000/hatetris.html')
+    console.log('http://localhost:3000/hatetris.html')
   })

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,23 @@
+const express = require('express')
+const WebpackDevServerUtils = require('react-dev-utils/WebpackDevServerUtils')
+const openBrowser = require('react-dev-utils/openBrowser')
+const webpack = require('webpack')
+const WebpackDevMiddleware = require('webpack-dev-middleware')
+const WebpackHotMiddleware = require('webpack-hot-middleware')
+
+const config = require('../config/webpack.config.dev')
+
+const compiler = WebpackDevServerUtils.createCompiler({
+  webpack,
+  config,
+  appName: 'hatetris',
+  urls: WebpackDevServerUtils.prepareUrls('http', 'localhost', 3000)
+})
+
+express()
+  .use(WebpackDevMiddleware(compiler))
+  .use(WebpackHotMiddleware(compiler))
+  .listen(3000, () => {
+    console.log('listening')
+    openBrowser('http://localhost:3000/hatetris.html')
+  })


### PR DESCRIPTION
* Move production webpack configuration to `config`.
* Fix the production configuration to actually do something production-sensible with the source code. You know, minify it?
* Add a development webpack configuration. This is derived from the production configuration but with some extra stuff added for HMR.
  * Note: React HMR isn't working because it seems to be pretty stupid in webpack 5 (all the plugins for this purpose appear to be experimental and, from my perspective, flatly do not work).
* Move the Cypress server script to `scripts/start-built.js`.
* Add another `scripts/start.js` which starts webpack's development server. At last, I don't need to rebuild the entire thing to test a single-character change.
* Rejig all the `npm` scripts somewhat.
  * Allow Cypress tests to run against the dev server.