### PR TITLE
A dedicated copy button

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,9 @@ module.exports = {
     'plugin:react/recommended',
     'standard'
   ],
+  ignorePatterns: [
+    'dist'
+  ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaFeatures: {

--- a/config/jestSetup.js
+++ b/config/jestSetup.js
@@ -2,3 +2,14 @@ const Enzyme = require('enzyme')
 const EnzymeAdapterReact16 = require('enzyme-adapter-react-16')
 
 Enzyme.configure({ adapter: new EnzymeAdapterReact16() })
+
+// Need for clipboard testing
+navigator.clipboard = {
+  writeText (text) {
+    this.text = text
+    return Promise.resolve()
+  },
+  readText () {
+    return Promise.resolve(this.text)
+  }
+}

--- a/cypress/integration/play.js
+++ b/cypress/integration/play.js
@@ -3,7 +3,7 @@
 describe('HATETRIS', () => {
   it('plays a game', () => {
     cy.visit('http://localhost:3000/hatetris.html')
-    cy.contains('You\'re playing HATETRIS by qntm')
+    cy.contains('you\'re playing HATETRIS by qntm')
 
     cy.get('button').contains('start new game').click()
     cy.get('.e2e__score').contains('0')

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "webpack --config ./config/webpack.config.prod.js",
     "cypress": "start-server-and-test \"npm run start\" http://localhost:3000/hatetris.html \"cypress run\"",
     "cypress-built": "start-server-and-test \"npm run start-built\" http://localhost:3000/hatetris.html \"cypress run\"",
-    "eslint": "eslint src --ext .ts,.tsx",
+    "eslint": "eslint . --ext .js,.ts,.tsx",
     "jest": "jest",
     "pretest": "npm run eslint",
     "start": "node scripts/start.js",

--- a/src/components/Game/Game.css
+++ b/src/components/Game/Game.css
@@ -29,7 +29,33 @@
 }
 
 .game__replay-out {
+	background-color: rgba(189, 189, 189, .3);
+	padding: .5rem;
+	line-height: normal;
 	word-break: break-all;
+}
+
+.game__button {
+	border: 0;
+	font-size: 1em; /* avoid shrinkage */
+	font-family: inherit;
+	padding: .5rem .75rem;
+	background-color: rgb(16, 82, 225);
+	color: white;
+	cursor: pointer;
+	line-height: 1rem;
+}
+
+.game__button:hover {
+	background-color: rgb(5, 52, 185);
+}
+
+.game__button:active {
+	background-color: red;
+}
+
+:focus {
+	outline: 2px solid black;
 }
 
 .game__spacer {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1735353/117583404-de23c500-b0fe-11eb-8506-9b0ada06ab72.png)

The replay now renders in a grey box and has a button "copy replay" beneath it.

* Altered the `eslint` script to examine *all* of the code in this repo, including `config` and `scripts`, not just `src`.
  * It ignores `dist`
* Updated `jestSetup.js` to mock out the Clipboard API we use.
* All buttons in the game are now a uniform blue, darkened when hovered over and red when clicked on.
* All focusable elements in the game now have a black outline when focused.
* Buttons now have testing-specific class names separate from formatting-specific class names.
* Upgrade `<Game>`'s unit tests to test not only the replay copying behaviour but also the expiry of the "copied!" text.
  * TODO: really this fading thing should be something we can encapsulate instead of tediously maintaining state, surely?