### PR TITLE
Make the game vaguely tolerable on mobile

### DIFF
--- a/src/components/Game/Game.css
+++ b/src/components/Game/Game.css
@@ -1,21 +1,31 @@
 .game {
 	box-sizing: border-box;
-	width: 100%;
-	height: 100%;
+	width: 100vw;
+	max-width: 360px;
+	height: 100vh;
+	margin: 0 auto;
 	font-family: arial;
-	padding: 50px;
+	padding: 10px;
 	display: flex;
+	flex-direction: column;
+	gap: 10px;
 }
 
-.game__left {
+.game__top {
+	flex: 0 0 auto;
+	display: flex;
+	gap: 10px;
+	flex-direction: row;
+}
+
+.game__topleft {
 	flex: 0 0 auto;
 }
 
-.game__right {
+.game__topright {
 	flex: 1 1 auto;
 	display: flex;
 	flex-direction: column;
-	padding: 10px;
 }
 
 .game__paragraph {
@@ -30,13 +40,18 @@
 
 .game__replay-out {
 	background-color: rgba(189, 189, 189, .3);
-	padding: .5rem;
+	width: 100%;
+	padding: 8px;
 	line-height: normal;
-	word-break: break-all;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-bottom: 10px;
 }
 
 .game__button {
 	border: 0;
+	height: 48px;
+	width: 100%;
 	font-size: 1em; /* avoid shrinkage */
 	font-family: inherit;
 	padding: .5rem .75rem;
@@ -54,10 +69,52 @@
 	background-color: red;
 }
 
+.game__button[disabled] {
+	background-color: grey;
+	cursor: default;
+}
+
 :focus {
 	outline: 2px solid black;
 }
 
 .game__spacer {
 	flex: 1 1 auto;
+}
+
+.game__bottom {
+	flex: 1 1 auto;
+}
+
+.game__bottom--initial {
+	display: block;
+}
+
+.game__bottom--playing {
+	display: flex;
+	gap: 10px;
+}
+
+.game__bottomleft {
+	flex: 0 1 50%;
+}
+
+.game__bottomright {
+	flex: 0 1 50%;
+}
+
+.game__control-col {
+	flex: 0 1 33%;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.game__game-over-buttons {
+	display: flex;
+	gap: 10px;
+}
+
+.game__button--game-over {
+	flex: 0 1 33%;
 }

--- a/src/components/Game/Game.spec.tsx
+++ b/src/components/Game/Game.spec.tsx
@@ -55,7 +55,7 @@ describe('<Game>', () => {
     expect(game.state()).toEqual({
       enemyAi: expect.any(Function),
       firstWellState,
-      mode: 'GAME_OVER',
+      mode: 'INITIAL',
       wellStateId: -1,
       wellStates: [],
       replay: [],
@@ -69,13 +69,13 @@ describe('<Game>', () => {
     game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'Right' }))
     game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'Down' }))
     game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'Up' }))
-    game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'Z', ctrlKey: true }))
-    game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'Y', ctrlKey: true }))
+    game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'z', ctrlKey: true }))
+    game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'y', ctrlKey: true }))
     expect(warn).toHaveBeenCalledTimes(6)
     expect(game.state()).toEqual({
       enemyAi: expect.any(Function),
       firstWellState,
-      mode: 'GAME_OVER',
+      mode: 'INITIAL',
       wellStateId: -1,
       wellStates: [],
       replay: [],
@@ -92,7 +92,7 @@ describe('<Game>', () => {
     expect(game.state()).toEqual({
       enemyAi: expect.any(Function),
       firstWellState,
-      mode: 'GAME_OVER',
+      mode: 'INITIAL',
       wellStateId: -1,
       wellStates: [],
       replay: [],
@@ -220,7 +220,7 @@ describe('<Game>', () => {
       replayTimeoutId: undefined
     })
 
-    game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'Z', ctrlKey: true }))
+    game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'z', ctrlKey: true }))
     expect(game.state()).toEqual({
       enemyAi: expect.any(Function),
       firstWellState,
@@ -252,7 +252,7 @@ describe('<Game>', () => {
       replayTimeoutId: undefined
     })
 
-    game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'Y', ctrlKey: true }))
+    game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'y', ctrlKey: true }))
     expect(game.state()).toEqual({
       enemyAi: expect.any(Function),
       firstWellState,
@@ -288,7 +288,7 @@ describe('<Game>', () => {
     const warn = jest.spyOn(console, 'warn')
     warn.mockImplementation(() => {})
 
-    game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'Y', ctrlKey: true }))
+    game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'y', ctrlKey: true }))
     expect(warn).toHaveBeenCalledTimes(1)
 
     warn.mockRestore()
@@ -354,7 +354,8 @@ describe('<Game>', () => {
     })
 
     it('lets you start a new game', () => {
-      game.find('.e2e__start-button').simulate('click')
+      // TODO: this is no longer provided in the UI...
+      game.instance().handleClickStart()
       expect(game.state()).toEqual(expect.objectContaining({
         enemyAi: expect.any(Function),
         firstWellState,
@@ -368,9 +369,10 @@ describe('<Game>', () => {
     })
 
     it('lets you start a new replay', () => {
+      // TODO: this is no longer provided in the UI...
       const prompt = jest.spyOn(window, 'prompt')
       prompt.mockReturnValueOnce('AAAA 1234 BCDE 2345 CDEF 3456')
-      game.find('.e2e__replay-button').simulate('click')
+      game.instance().handleClickReplay()
       prompt.mockRestore()
 
       expect(game.state()).toEqual(expect.objectContaining({
@@ -386,7 +388,7 @@ describe('<Game>', () => {
     })
 
     it('lets you undo and stops replaying if you do so', () => {
-      game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'Z', ctrlKey: true }))
+      game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'z', ctrlKey: true }))
       expect(game.state()).toEqual(expect.objectContaining({
         enemyAi: expect.any(Function),
         firstWellState,
@@ -503,11 +505,13 @@ describe('<Game>', () => {
 
                 // "copied!" disappears after a while
                 expect(game.state().replayCopiedTimeoutId).toEqual(expect.any(Number))
-                expect(game.find('.e2e__copied').text()).toBe('copied!')
+                expect(game.find('.e2e__copy-replay').text()).toBe('copied!')
 
                 jest.runAllTimers()
                 expect(game.state().replayCopiedTimeoutId).toBeUndefined()
 
+                game.find('.e2e__done').simulate('click')
+                expect(game.state().mode).toBe('INITIAL')
                 game.unmount()
 
                 // TODO: maybe some assertions about how many trailing moves were ignored

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -90,7 +90,7 @@ class Game extends React.Component<GameProps, GameState> {
     this.state = {
       enemyAi,
       firstWellState,
-      mode: 'GAME_OVER',
+      mode: 'INITIAL',
       wellStateId: -1,
       wellStates: [],
       replay: [],
@@ -444,11 +444,12 @@ class Game extends React.Component<GameProps, GameState> {
       this.handleUp()
     }
 
-    if (event.key === 'Z' && event.ctrlKey === true) {
+    console.log(event.key, event.ctrlKey)
+    if (event.key === 'z' && event.ctrlKey === true) {
       this.handleUndo()
     }
 
-    if (event.key === 'Y' && event.ctrlKey === true) {
+    if (event.key === 'y' && event.ctrlKey === true) {
       this.handleRedo()
     }
   }
@@ -470,6 +471,12 @@ class Game extends React.Component<GameProps, GameState> {
   handleCopiedTimeout = () => {
     this.setState({
       replayCopiedTimeoutId: undefined
+    })
+  }
+
+  handleClickDone = () => {
+    this.setState({
+      mode: 'INITIAL'
     })
   }
 
@@ -495,96 +502,176 @@ class Game extends React.Component<GameProps, GameState> {
 
     return (
       <div className='game'>
-        <div className='game__left'>
-          <Well
-            bar={bar}
-            rotationSystem={rotationSystem}
-            wellDepth={wellDepth}
-            wellWidth={wellWidth}
-            wellState={wellState}
-            onClickL={this.handleLeft}
-            onClickR={this.handleRight}
-            onClickU={this.handleUp}
-            onClickD={this.handleDown}
-            onClickZ={this.handleUndo}
-            onClickY={this.handleRedo}
-          />
-        </div>
-        <div className='game__right'>
-          <p className='game__paragraph'>
-            <a href='http://qntm.org/hatetris'>
-              you&apos;re playing HATETRIS by qntm
-            </a>
-          </p>
-
-          <p className='game__paragraph'>
-            <button
-              className='game__button e2e__start-button'
-              type='button'
-              onClick={this.handleClickStart}
-            >
-              start new game
-            </button>
-          </p>
-
-          <p className='game__paragraph'>
-            <button
-              className='game__button e2e__replay-button'
-              type='button'
-              onClick={this.handleClickReplay}
-            >
-              show a replay
-            </button>
-          </p>
-
-          {score !== null && (
+        <div className='game__top'>
+          <div className='game__topleft'>
+            <Well
+              bar={bar}
+              rotationSystem={rotationSystem}
+              wellDepth={wellDepth}
+              wellWidth={wellWidth}
+              wellState={wellState}
+            />
+          </div>
+          <div className='game__topright'>
             <p className='game__paragraph'>
-              <span className='e2e__score'>
-                score: {score}
-              </span>
+              you&apos;re playing <b>HATETRIS</b> by qntm
             </p>
-          )}
 
-          {mode === 'GAME_OVER' && replay.length > 0 && (
-            <>
-              <p className='game__paragraph'>
-                replay of last game:
+            {score !== null && (
+              <p className='game__paragraph e2e__score'>
+                score: {score}
               </p>
-              <p className='game__paragraph game__replay-out e2e__replay-out'>
-                {hatetrisReplayCodec.encode(replay)}
-              </p>
-              <p className='game__paragraph'>
-                <button
-                  className='game__button e2e__copy-replay'
-                  type='button'
-                  onClick={this.handleClickCopyReplay}
-                >
-                  copy replay
-                </button>
-              </p>
-              {replayCopiedTimeoutId && (
-                <p className='game__paragraph e2e__copied'>
-                  copied!
-                </p>
-              )}
-            </>
-          )}
+            )}
 
-          <div className='game__spacer' />
+            <div className='game__spacer' />
 
-          <p className='game__paragraph'>
-            undo: Ctrl+Z<br />
-            redo: Ctrl+Y<br />
-          </p>
+            <p className='game__paragraph'>
+              <a href='http://qntm.org/hatetris'>
+                about
+              </a>
+            </p>
 
-          <p className='game__paragraph'>
-            <a href='https://github.com/qntm/hatetris'>source code</a>
-          </p>
+            <p className='game__paragraph'>
+              <a href='https://github.com/qntm/hatetris'>
+                source code
+              </a>
+            </p>
 
-          <p className='game__paragraph'>
-            replays encoded using <a href='https://github.com/qntm/base2048'>Base2048</a><br />
-          </p>
+            <p className='game__paragraph'>
+              replays encoded using <a href='https://github.com/qntm/base2048'>Base2048</a>
+            </p>
+          </div>
         </div>
+
+        {mode === 'INITIAL' && (
+          <div className='game__bottom game__bottom--initial'>
+            <p className='game__paragraph'>
+              <button
+                className='game__button e2e__start-button'
+                type='button'
+                onClick={this.handleClickStart}
+              >
+                start new game
+              </button>
+            </p>
+
+            <p className='game__paragraph'>
+              <button
+                className='game__button e2e__replay-button'
+                type='button'
+                onClick={this.handleClickReplay}
+              >
+                show a replay
+              </button>
+            </p>
+          </div>
+        )}
+
+        {mode === 'PLAYING' && (
+          <div className='game__bottom game__bottom--playing'>
+            <div className='game__control-col'>
+              <button
+                className='game__button'
+                disabled={!(wellStateId - 1 in wellStates)}
+                type='button'
+                onClick={this.handleUndo}
+                title='Press Ctrl+Z to undo'
+              >
+                ↶
+              </button>
+
+              <button
+                className='game__button'
+                type='button'
+                onClick={this.handleLeft}
+                title='Press Left to move left'
+              >
+                ←
+              </button>
+            </div>
+            <div className='game__control-col'>
+              <button
+                className='game__button'
+                type='button'
+                onClick={this.handleUp}
+                title='Press Up to rotate'
+              >
+                ⟳
+              </button>
+
+              <button
+                className='game__button'
+                type='button'
+                onClick={this.handleDown}
+                title='Press Down to move down'
+              >
+                ↓
+              </button>
+            </div>
+            <div className='game__control-col'>
+              <button
+                className='game__button'
+                disabled={!(wellStateId + 1 in wellStates)}
+                type='button'
+                onClick={this.handleRedo}
+                title='Press Ctrl+Y to redo'
+              >
+                ↷
+              </button>
+
+              <button
+                className='game__button'
+                type='button'
+                onClick={this.handleRight}
+                title='Press Right to move right'
+              >
+                →
+              </button>
+            </div>
+          </div>
+        )}
+
+        {mode === 'REPLAYING' && (
+          <div className='game__bottom game__bottom--replaying'>
+            replaying...
+          </div>
+        )}
+
+        {mode === 'GAME_OVER' && (
+          <div className='game__bottom game__bottom--game-over'>
+            <p className='game__paragraph'>
+              replay of last game:
+            </p>
+            <div className='game__replay-out e2e__replay-out'>
+              {hatetrisReplayCodec.encode(replay).repeat(15)}
+            </div>
+            <div className='game__game-over-buttons'>
+              <button
+                className='game__button game__button--game-over e2e__replay-button'
+                type='button'
+                onClick={this.handleUndo}
+              >
+                undo last move
+              </button>
+
+              <button
+                className='game__button game__button--game-over e2e__copy-replay'
+                type='button'
+                onClick={this.handleClickCopyReplay}
+              >
+                {replayCopiedTimeoutId ? 'copied!' : 'copy replay'}
+              </button>
+
+              <button
+                className='game__button game__button--game-over e2e__done'
+                type='button'
+                onClick={this.handleClickDone}
+              >
+                done
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     )
   }

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -7,7 +7,7 @@
 import * as React from 'react'
 
 import hatetrisReplayCodec from '../../replay-codecs/hatetris-replay-codec'
-import Well from '../Well/Well'
+import { Well } from '../Well/Well'
 import './Game.css'
 
 const minWidth = 4
@@ -444,7 +444,6 @@ class Game extends React.Component<GameProps, GameState> {
       this.handleUp()
     }
 
-    console.log(event.key, event.ctrlKey)
     if (event.key === 'z' && event.ctrlKey === true) {
       this.handleUndo()
     }

--- a/src/components/Well/Well.css
+++ b/src/components/Well/Well.css
@@ -1,6 +1,6 @@
 .well__cell {
-	width: 25px;
-	height: 25px;
+	width: 20px;
+	height: 20px;
 	color: white;
 	background-color: black;
 	padding: 0;
@@ -10,10 +10,6 @@
 
 .well__cell--bar {
 	border-top: 1px solid red;
-}
-
-.well__cell--manual {
-	cursor: pointer;
 }
 
 .well__cell--landed {

--- a/src/components/Well/Well.spec.tsx
+++ b/src/components/Well/Well.spec.tsx
@@ -5,7 +5,7 @@
 import { shallow } from 'enzyme'
 import * as React from 'react'
 
-import Well from './Well'
+import { Well } from './Well'
 import type { WellProps } from './Well'
 import hatetrisRotationSystem from '../../rotation-systems/hatetris-rotation-system'
 

--- a/src/components/Well/Well.spec.tsx
+++ b/src/components/Well/Well.spec.tsx
@@ -20,27 +20,14 @@ describe('<Well>', () => {
       rotationSystem={hatetrisRotationSystem}
       wellDepth={wellDepth}
       wellWidth={wellWidth}
-      onClickL={jest.fn()}
-      onClickR={jest.fn()}
-      onClickU={jest.fn()}
-      onClickD={jest.fn()}
-      onClickZ={jest.fn()}
-      onClickY={jest.fn()}
       wellState={null}
       {...props}
     />
   )
 
   it('null well state', () => {
-    const onClickD = jest.fn()
-    const well = getWell({ onClickD })
+    const well = getWell()
     expect(well).toMatchSnapshot()
-
-    const downCell = well.find('tr').at(1).find('td').at(1)
-    expect(downCell.text()).toBe('\u2193')
-    expect(downCell.props().title).toBe('Press Down to move down')
-    downCell.simulate('click')
-    expect(onClickD).toHaveBeenCalled()
   })
 
   it('initial well state', () => {

--- a/src/components/Well/Well.tsx
+++ b/src/components/Well/Well.tsx
@@ -21,7 +21,7 @@ type Cell = {
 
 export type { WellProps }
 
-export default (props: WellProps) => {
+export const Well = (props: WellProps) => {
   const {
     bar,
     rotationSystem,

--- a/src/components/Well/Well.tsx
+++ b/src/components/Well/Well.tsx
@@ -11,21 +11,12 @@ type WellProps = {
   rotationSystem: any;
   wellDepth: number;
   wellWidth: number;
-  onClickL: () => void;
-  onClickR: () => void;
-  onClickU: () => void;
-  onClickD: () => void;
-  onClickZ: () => void;
-  onClickY: () => void;
   wellState: GameWellState
 }
 
 type Cell = {
   landed: boolean,
-  live: boolean,
-  handleClick?: () => void,
-  symbol?: string,
-  title?: string
+  live: boolean
 }
 
 export type { WellProps }
@@ -36,12 +27,6 @@ export default (props: WellProps) => {
     rotationSystem,
     wellDepth,
     wellWidth,
-    onClickL,
-    onClickR,
-    onClickU,
-    onClickD,
-    onClickZ,
-    onClickY,
     wellState
   } = props
 
@@ -73,22 +58,6 @@ export default (props: WellProps) => {
     cellses.push(cells)
   }
 
-  // put some buttons on the playing field
-  const buttons = [
-    { y: 0, x: 0, handleClick: onClickZ, symbol: '\u21B6', title: 'Press Ctrl+Z to undo' },
-    { y: 0, x: 1, handleClick: onClickU, symbol: '\u27F3', title: 'Press Up to rotate' },
-    { y: 0, x: 2, handleClick: onClickY, symbol: '\u21B7', title: 'Press Ctrl+Y to redo' },
-    { y: 1, x: 0, handleClick: onClickL, symbol: '\u2190', title: 'Press Left to move left' },
-    { y: 1, x: 1, handleClick: onClickD, symbol: '\u2193', title: 'Press Down to move down' },
-    { y: 1, x: 2, handleClick: onClickR, symbol: '\u2192', title: 'Press Right to move right' }
-  ]
-
-  buttons.forEach(button => {
-    cellses[button.y][button.x].handleClick = button.handleClick
-    cellses[button.y][button.x].symbol = button.symbol
-    cellses[button.y][button.x].title = button.title
-  })
-
   return (
     <table>
       <tbody>
@@ -100,15 +69,10 @@ export default (props: WellProps) => {
                 className={classnames({
                   well__cell: true,
                   'well__cell--bar': y === bar,
-                  'well__cell--manual': cell.handleClick,
                   'well__cell--landed': cell.landed,
                   'well__cell--live': cell.live
                 })}
-                onClick={cell.handleClick}
-                title={cell.title}
-              >
-                {cell.symbol}
-              </td>
+              />
             ))}
           </tr>
         ))}

--- a/src/components/Well/__snapshots__/Well.spec.tsx.snap
+++ b/src/components/Well/__snapshots__/Well.spec.tsx.snap
@@ -7,29 +7,17 @@ exports[`<Well> game over well state 1`] = `
       key="0"
     >
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="0"
-        onClick={[MockFunction]}
-        title="Press Ctrl+Z to undo"
-      >
-        ↶
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="1"
-        onClick={[MockFunction]}
-        title="Press Up to rotate"
-      >
-        ⟳
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="2"
-        onClick={[MockFunction]}
-        title="Press Ctrl+Y to redo"
-      >
-        ↷
-      </td>
+      />
       <td
         className="well__cell"
         key="3"
@@ -63,29 +51,17 @@ exports[`<Well> game over well state 1`] = `
       key="1"
     >
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="0"
-        onClick={[MockFunction]}
-        title="Press Left to move left"
-      >
-        ←
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="1"
-        onClick={[MockFunction]}
-        title="Press Down to move down"
-      >
-        ↓
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="2"
-        onClick={[MockFunction]}
-        title="Press Right to move right"
-      >
-        →
-      </td>
+      />
       <td
         className="well__cell"
         key="3"
@@ -918,29 +894,17 @@ exports[`<Well> initial well state 1`] = `
       key="0"
     >
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="0"
-        onClick={[MockFunction]}
-        title="Press Ctrl+Z to undo"
-      >
-        ↶
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="1"
-        onClick={[MockFunction]}
-        title="Press Up to rotate"
-      >
-        ⟳
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="2"
-        onClick={[MockFunction]}
-        title="Press Ctrl+Y to redo"
-      >
-        ↷
-      </td>
+      />
       <td
         className="well__cell"
         key="3"
@@ -974,29 +938,17 @@ exports[`<Well> initial well state 1`] = `
       key="1"
     >
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="0"
-        onClick={[MockFunction]}
-        title="Press Left to move left"
-      >
-        ←
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="1"
-        onClick={[MockFunction]}
-        title="Press Down to move down"
-      >
-        ↓
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="2"
-        onClick={[MockFunction]}
-        title="Press Right to move right"
-      >
-        →
-      </td>
+      />
       <td
         className="well__cell"
         key="3"
@@ -1829,29 +1781,17 @@ exports[`<Well> null well state 1`] = `
       key="0"
     >
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="0"
-        onClick={[MockFunction]}
-        title="Press Ctrl+Z to undo"
-      >
-        ↶
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="1"
-        onClick={[MockFunction]}
-        title="Press Up to rotate"
-      >
-        ⟳
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="2"
-        onClick={[MockFunction]}
-        title="Press Ctrl+Y to redo"
-      >
-        ↷
-      </td>
+      />
       <td
         className="well__cell"
         key="3"
@@ -1885,29 +1825,17 @@ exports[`<Well> null well state 1`] = `
       key="1"
     >
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="0"
-        onClick={[MockFunction]}
-        title="Press Left to move left"
-      >
-        ←
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="1"
-        onClick={[MockFunction]}
-        title="Press Down to move down"
-      >
-        ↓
-      </td>
+      />
       <td
-        className="well__cell well__cell--manual"
+        className="well__cell"
         key="2"
-        onClick={[MockFunction]}
-        title="Press Right to move right"
-      >
-        →
-      </td>
+      />
       <td
         className="well__cell"
         key="3"

--- a/src/index.css
+++ b/src/index.css
@@ -107,3 +107,7 @@ blockquote,
 q {
 	quotes: "" "";
 }
+
+* {
+	box-sizing: border-box;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1735353/117591651-54d7b700-b12d-11eb-907a-9abb6954669a.png)

* Overhaul all button placement and CSS. Buttons are no longer weeny little areas in the top left, they are big rectangular buttons below the main playing area. This means six props are no longer passed into `<Well>`.
* Use Flexbox to position stuff properly.
* Separate out a new game state `'INITIAL'` from `'GAME_OVER'` - in `'INITIAL'` state we show only the "start new game" and "show a replay" buttons, whereas in `'GAME_OVER'` state we show the replay string and the buttons "undo last move", "copy replay" and "done", the latter of which takes you back to `'INITIAL'`.
* Fix a bug where Ctrl+Z and Ctrl+Y didn't seem to be working.
* Make the well a tad smaller, for mobile.