### PR TITLE
A more coherent enemy AI API

### DIFF
--- a/src/components/Game/Game.spec.tsx
+++ b/src/components/Game/Game.spec.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 
 import Game from './Game'
 import type { GameProps } from './Game'
-import { HatetrisAi } from '../../enemy-ais/hatetris-ai'
+import { hatetrisAi } from '../../enemy-ais/hatetris-ai'
 import hatetrisRotationSystem from '../../rotation-systems/hatetris-rotation-system'
 
 jest.useFakeTimers()
@@ -17,7 +17,7 @@ describe('<Game>', () => {
     return shallow<Game>(
       <Game
         bar={4}
-        EnemyAi={HatetrisAi}
+        enemyAi={hatetrisAi}
         replayTimeout={0}
         rotationSystem={hatetrisRotationSystem}
         wellDepth={20}
@@ -36,7 +36,7 @@ describe('<Game>', () => {
   it('rejects a rotation system with no pieces', () => {
     expect(() => getGame({
       rotationSystem: {
-        placeNewPiece: () => {},
+        placeNewPiece: () => ({ id: '', o: NaN, x: NaN, y: NaN }),
         rotations: {}
       }
     })).toThrowError()
@@ -53,7 +53,7 @@ describe('<Game>', () => {
   it('ignores all keystrokes before the game has begun', () => {
     const game = getGame()
     expect(game.state()).toEqual({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'INITIAL',
       wellStateId: -1,
@@ -73,7 +73,7 @@ describe('<Game>', () => {
     game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'y', ctrlKey: true }))
     expect(warn).toHaveBeenCalledTimes(6)
     expect(game.state()).toEqual({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'INITIAL',
       wellStateId: -1,
@@ -90,7 +90,7 @@ describe('<Game>', () => {
   it('lets you play a few moves', () => {
     const game = getGame()
     expect(game.state()).toEqual({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'INITIAL',
       wellStateId: -1,
@@ -102,7 +102,7 @@ describe('<Game>', () => {
 
     game.find('.e2e__start-button').simulate('click')
     expect(game.state()).toEqual({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'PLAYING',
       wellStateId: 0,
@@ -118,7 +118,7 @@ describe('<Game>', () => {
 
     game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'ArrowLeft' }))
     expect(game.state()).toEqual({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'PLAYING',
       wellStateId: 1,
@@ -138,7 +138,7 @@ describe('<Game>', () => {
 
     game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'ArrowRight' }))
     expect(game.state()).toEqual({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'PLAYING',
       wellStateId: 2,
@@ -162,7 +162,7 @@ describe('<Game>', () => {
 
     game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'ArrowDown' }))
     expect(game.state()).toEqual({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'PLAYING',
       wellStateId: 3,
@@ -190,7 +190,7 @@ describe('<Game>', () => {
 
     game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'ArrowUp' }))
     expect(game.state()).toEqual({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'PLAYING',
       wellStateId: 4,
@@ -222,7 +222,7 @@ describe('<Game>', () => {
 
     game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'z', ctrlKey: true }))
     expect(game.state()).toEqual({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'PLAYING',
       wellStateId: 3,
@@ -254,7 +254,7 @@ describe('<Game>', () => {
 
     game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'y', ctrlKey: true }))
     expect(game.state()).toEqual({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'PLAYING',
       wellStateId: 4,
@@ -304,7 +304,7 @@ describe('<Game>', () => {
     prompt.mockRestore()
 
     expect(game.state()).toEqual(expect.objectContaining({
-      enemyAi: expect.any(Function),
+      enemyAi: hatetrisAi,
       firstWellState,
       mode: 'PLAYING',
       replay: [],
@@ -335,7 +335,7 @@ describe('<Game>', () => {
       jest.runOnlyPendingTimers()
 
       expect(game.state()).toEqual(expect.objectContaining({
-        enemyAi: expect.any(Function),
+        enemyAi: hatetrisAi,
         firstWellState,
         mode: 'REPLAYING',
         wellStates: [
@@ -357,7 +357,7 @@ describe('<Game>', () => {
       // TODO: this is no longer provided in the UI...
       game.instance().handleClickStart()
       expect(game.state()).toEqual(expect.objectContaining({
-        enemyAi: expect.any(Function),
+        enemyAi: hatetrisAi,
         firstWellState,
         mode: 'PLAYING',
         wellStates: [
@@ -376,7 +376,7 @@ describe('<Game>', () => {
       prompt.mockRestore()
 
       expect(game.state()).toEqual(expect.objectContaining({
-        enemyAi: expect.any(Function),
+        enemyAi: hatetrisAi,
         firstWellState,
         mode: 'REPLAYING',
         wellStates: [
@@ -390,7 +390,7 @@ describe('<Game>', () => {
     it('lets you undo and stops replaying if you do so', () => {
       game.instance().handleDocumentKeyDown(new window.KeyboardEvent('keydown', { key: 'z', ctrlKey: true }))
       expect(game.state()).toEqual(expect.objectContaining({
-        enemyAi: expect.any(Function),
+        enemyAi: hatetrisAi,
         firstWellState,
         mode: 'PLAYING', // no longer replaying
         wellStates: [

--- a/src/enemy-ais/hatetris-ai.spec.tsx
+++ b/src/enemy-ais/hatetris-ai.spec.tsx
@@ -6,18 +6,18 @@ import { shallow } from 'enzyme'
 import * as React from 'react'
 
 import Game from '../components/Game/Game'
-import { HatetrisAi, LovetrisAi } from './hatetris-ai'
+import { hatetrisAi, lovetrisAi } from './hatetris-ai'
 import hatetrisRotationSystem from '../rotation-systems/hatetris-rotation-system'
 
 // Note: well bits are flipped compared to what you would see on the screen.
 // Least significant bit is rendered on the *left* on web, but appears to the
 // *right* of each binary numeric literal
 
-describe('HatetrisAi', () => {
+describe('hatetrisAi', () => {
   const game = shallow<Game>(
     <Game
       bar={4}
-      EnemyAi={HatetrisAi}
+      enemyAi={hatetrisAi}
       replayTimeout={0}
       rotationSystem={hatetrisRotationSystem}
       wellDepth={8}
@@ -25,10 +25,10 @@ describe('HatetrisAi', () => {
     />
   )
 
-  const hatetris = game.state().enemyAi
+  const getPossibleFutures = game.instance().getPossibleFutures
 
   it('generates an S by default', () => {
-    expect(hatetris([
+    expect(hatetrisAi([
       0b0000000000,
       0b0000000000,
       0b0000000000,
@@ -37,11 +37,11 @@ describe('HatetrisAi', () => {
       0b0000000000,
       0b0000000000,
       0b0000000000
-    ])).toBe('S')
+    ], getPossibleFutures)).toBe('S')
   })
 
   it('generates a Z when an S would result in a lower stack', () => {
-    expect(hatetris([
+    expect(hatetrisAi([
       0b0000000000,
       0b0000000000,
       0b0000000000,
@@ -50,11 +50,11 @@ describe('HatetrisAi', () => {
       0b0000000000,
       0b0001000000,
       0b1111011111
-    ])).toBe('Z')
+    ], getPossibleFutures)).toBe('Z')
   })
 
   it('generates an O when an S or Z would result in a lower stack', () => {
-    expect(hatetris([
+    expect(hatetrisAi([
       0b0000000000,
       0b0000000000,
       0b0000000000,
@@ -63,11 +63,11 @@ describe('HatetrisAi', () => {
       0b0000000000,
       0b0000000000,
       0b1111101111
-    ])).toBe('O')
+    ], getPossibleFutures)).toBe('O')
   })
 
   it('generates an I when an S, Z or O would result in a lower stack', () => {
-    expect(hatetris([
+    expect(hatetrisAi([
       0b0000000000,
       0b0000000000,
       0b0000000000,
@@ -76,11 +76,11 @@ describe('HatetrisAi', () => {
       0b0000000000,
       0b0000000000,
       0b1111001111
-    ])).toBe('I')
+    ], getPossibleFutures)).toBe('I')
   })
 
   it('generates an L when an S, Z, O or I would result in a lower stack', () => {
-    expect(hatetris([
+    expect(hatetrisAi([
       0b0000000000,
       0b0000000000,
       0b0000000000,
@@ -89,11 +89,11 @@ describe('HatetrisAi', () => {
       0b1111100111,
       0b1011100111,
       0b1111110111
-    ])).toBe('L')
+    ], getPossibleFutures)).toBe('L')
   })
 
   it('generates a J when an S, Z, O, I or L would result in a lower stack', () => {
-    expect(hatetris([
+    expect(hatetrisAi([
       0b0000000000,
       0b0000000000,
       0b0000000000,
@@ -102,11 +102,11 @@ describe('HatetrisAi', () => {
       0b1111100111,
       0b1011100111,
       0b1111101111
-    ])).toBe('J')
+    ], getPossibleFutures)).toBe('J')
   })
 
   it('generates a T when an S, Z, O, I, L or J would result in a lower stack', () => {
-    expect(hatetris([
+    expect(hatetrisAi([
       0b0000000000,
       0b0000000000,
       0b0000000000,
@@ -115,7 +115,7 @@ describe('HatetrisAi', () => {
       0b1000000000,
       0b1111000011,
       0b1111100111
-    ])).toBe('T')
+    ], getPossibleFutures)).toBe('T')
   })
 
   // Only while writing these unit tests did I discover this subtle piece of
@@ -124,7 +124,7 @@ describe('HatetrisAi', () => {
   // reaching y = 6. L comes first so it is selected. This happens even though
   // L and J *give you a line* while T would not.
   it('just gives you a line sometimes!', () => {
-    expect(hatetris([
+    expect(hatetrisAi([
       0b0000000000,
       0b0000000000,
       0b0000000000,
@@ -133,12 +133,12 @@ describe('HatetrisAi', () => {
       0b0000000000,
       0b1111000011,
       0b1111100111
-    ])).toBe('L')
+    ], getPossibleFutures)).toBe('L')
   })
 
   // Coverage...
   it('generates an S when say an I would clear the board', () => {
-    expect(hatetris([
+    expect(hatetrisAi([
       0b0000000000,
       0b0000000000,
       0b0000000000,
@@ -147,39 +147,15 @@ describe('HatetrisAi', () => {
       0b1111111110,
       0b1111111110,
       0b1111111110
-    ])).toBe('S')
-  })
-
-  it('throws an exception on an unrecognised piece', () => {
-    expect(() => shallow<Game>(
-      <Game
-        bar={4}
-        EnemyAi={HatetrisAi}
-        replayTimeout={0}
-        rotationSystem={{
-          rotations: {
-            DOT: [
-              { xMin: 0, yMin: 0, xDim: 1, yDim: 1, rows: [1] },
-              { xMin: 0, yMin: 0, xDim: 1, yDim: 1, rows: [1] },
-              { xMin: 0, yMin: 0, xDim: 1, yDim: 1, rows: [1] },
-              { xMin: 0, yMin: 0, xDim: 1, yDim: 1, rows: [1] }
-            ]
-          },
-          placeNewPiece: hatetrisRotationSystem.placeNewPiece
-        }}
-        wellDepth={8}
-        wellWidth={10}
-      />
-    ))
-      .toThrowError('Unrecognised piece')
+    ], getPossibleFutures)).toBe('S')
   })
 })
 
-describe('LovetrisAi', () => {
+describe('lovetrisAi', () => {
   const game = shallow<Game>(
     <Game
       bar={4}
-      EnemyAi={LovetrisAi}
+      enemyAi={lovetrisAi}
       replayTimeout={0}
       rotationSystem={hatetrisRotationSystem}
       wellDepth={8}
@@ -187,10 +163,10 @@ describe('LovetrisAi', () => {
     />
   )
 
-  const lovetris = game.state().enemyAi
+  const getPossibleFutures = game.instance().getPossibleFutures
 
   it('generates a T by default', () => {
-    expect(lovetris([
+    expect(lovetrisAi([
       0b0000000000,
       0b0000000000,
       0b0000000000,
@@ -199,6 +175,6 @@ describe('LovetrisAi', () => {
       0b1000000000,
       0b1000000000,
       0b1000000000
-    ])).toBe('T')
+    ], getPossibleFutures)).toBe('T')
   })
 })

--- a/src/enemy-ais/hatetris-ai.ts
+++ b/src/enemy-ais/hatetris-ai.ts
@@ -1,153 +1,53 @@
 'use strict'
 
-// TODO: this AI is needs to be made agnostic to the order of pieces
-// given in the rotation system. At present it just returns whatever
-// the first one is!
+import type { GameWellState, EnemyAi } from '../components/Game/Game.jsx'
 
-import Game from '../components/Game/Game.jsx'
-import type { GameWellState } from '../components/Game/Game.jsx'
-
-const moves = ['L', 'R', 'D', 'U']
-
-type PieceRankings = {
-  [pieceId: string]: number
-}
-
-const pieceRankings: PieceRankings = {
-  S: 1, // most preferable in a tie break
+const pieceRankings = {
+  S: 1, // most preferable to the AI in a tie break
   Z: 2,
   O: 3,
   I: 4,
   L: 5,
   J: 6,
-  T: 7 // least preferable in a tie break
+  T: 7 // least preferable to the AI in a tie break
 }
 
-const getPieceRanking = (pieceId: string): number => {
-  if (pieceId in pieceRankings) {
-    return pieceRankings[pieceId]
-  }
-
-  throw Error('Unrecognised piece')
-}
-
-const getHatetrisAi = (loveMode: boolean) => (game: Game) => {
-  const {
-    rotationSystem,
-    wellDepth,
-    wellWidth
-  } = game.props
-
-  /**
-    Generate a unique integer to describe the position and orientation of this piece.
-    `x` varies between -3 and (`wellWidth` - 1) inclusive, so range = `wellWidth` + 3
-    `y` varies between 0 and (`wellDepth` + 2) inclusive, so range = `wellDepth` + 3
-    `o` varies between 0 and 3 inclusive, so range = 4
-  */
-  const hashCode = (x: number, y: number, o: number) =>
-    (x * (wellDepth + 3) + y) * 4 + o
-
-  /**
-    Given a well and a piece ID, find all possible places where it could land
-    and return the array of "possible future" states. All of these states
-    will have `null` `piece` because the piece is landed; some will have
-    an increased `score`.
-  */
-  const getPossibleFutures = (well: number[], pieceId: string): GameWellState[] => {
-    let piece = rotationSystem.placeNewPiece(wellWidth, pieceId)
-
-    // move the piece down to a lower position before we have to
-    // start pathfinding for it
-    // move through empty rows
-    while (
-      piece.y + 4 < wellDepth && // piece is above the bottom
-      well[piece.y + 4] === 0 // nothing immediately below it
-    ) {
-      piece = game.getNextState({
-        well: well,
-        score: 0,
-        piece: piece
-      }, 'D').piece
-    }
-
-    // push first position
-    const piecePositions = [piece]
-
-    const seen = new Set()
-    seen.add(hashCode(piece.x, piece.y, piece.o))
-
-    const possibleFutures: GameWellState[] = []
-
-    // A simple `forEach` won't work here because we are appending to the list as we go
-    let i = 0
-    while (i < piecePositions.length) {
-      piece = piecePositions[i]
-
-      // apply all possible moves
-      moves.forEach(move => {
-        const nextState = game.getNextState({
-          well: well,
-          score: 0,
-          piece: piece
-        }, move)
-        const newPiece = nextState.piece
-
-        if (newPiece === null) {
-          // piece locked? better add that to the list
-          // do NOT check locations, they aren't significant here
-          possibleFutures.push(nextState)
-        } else {
-          // transform succeeded?
-          // new location? append to list
-          // check locations, they are significant
-          const newHashCode = hashCode(newPiece.x, newPiece.y, newPiece.o)
-
-          if (!seen.has(newHashCode)) {
-            piecePositions.push(newPiece)
-            seen.add(newHashCode)
-          }
-        }
-      })
-      i++
-    }
-
-    return possibleFutures
-  }
-
+const getHatetrisAi = (loveMode: boolean): EnemyAi =>
   // Pick the worst piece that could be put into this well.
   // Rating is the row where the highest blue appears, or `wellDepth` if the well is empty.
   // For the player, higher is better because it indicates a lower stack.
   // For the AI, lower is better
-  return (well: number[]): string => {
-    const highestRatings = Object.keys(rotationSystem.rotations).map(pieceId => {
-      let highestRating = -Infinity
-      getPossibleFutures(well, pieceId).forEach(possibleFuture => {
-        let rating = possibleFuture.well.findIndex(row => row !== 0)
+  (
+    well: number[],
+    getPossibleFutures: (well: number[], pieceId: string) => GameWellState[]
+  ): string => {
+    const highestRatings = Object.entries(pieceRankings)
+      .map(([pieceId, pieceRanking]) => ({
+        pieceId,
+        pieceRanking,
+        highestRating: Math.max(
+          ...getPossibleFutures(well, pieceId)
+            .map(possibleFuture => {
+              const rating = possibleFuture.well.findIndex(row => row !== 0)
 
-        if (rating === -1) {
-          // Well is completely empty after placing this piece in this location
-          // (note: this is impossible in practice)
-          rating = wellDepth
-        }
-
-        if (rating > highestRating) {
-          highestRating = rating
-        }
-      })
-
-      return { pieceId, pieceRanking: getPieceRanking(pieceId), highestRating }
-    })
+              return rating === -1
+                // Well is completely empty after placing this piece in this location
+                // (note: this is impossible in practice)
+                ? well.length
+                : rating
+            })
+        )
+      }))
 
     highestRatings.sort((a, b) =>
       (a.highestRating - b.highestRating) ||
 
       // Tie breaker is piece ID rating
-      a.pieceRanking - b.pieceRanking
+      (a.pieceRanking - b.pieceRanking)
     )
 
     return highestRatings[loveMode ? highestRatings.length - 1 : 0].pieceId
   }
-}
 
-export const HatetrisAi = getHatetrisAi(false)
-export const LovetrisAi = getHatetrisAi(true)
+export const hatetrisAi = getHatetrisAi(false)
+export const lovetrisAi = getHatetrisAi(true)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,14 +9,14 @@ import * as ReactDOM from 'react-dom'
 
 import './index.css'
 import Game from './components/Game/Game'
-import { HatetrisAi } from './enemy-ais/hatetris-ai'
+import { hatetrisAi } from './enemy-ais/hatetris-ai'
 import hatetrisRotationSystem from './rotation-systems/hatetris-rotation-system'
 
 ReactDOM.render(
   (
     <Game
       bar={4}
-      EnemyAi={HatetrisAi}
+      enemyAi={hatetrisAi}
       replayTimeout={50}
       rotationSystem={hatetrisRotationSystem}
       wellDepth={20}


### PR DESCRIPTION
As scaffolding for a future in which it's easier to switch between different enemy AIs and for people plug in new ones, I'm altering the overall API for the AI. The AI is now a function `(well, getPossibleFutures) => pieceId`. Here,

* `well` is an array of 20 binary numbers, one representing each row in the well. Each bit in each number represents a cell in that row which is currently filled/obstructed. (Note: the least significant bit represents the leftmost cell; so, if the value is `0b0000000011`, the leftmost two cells in the row are occupied).
* `getPossibleFutures` is a function `(well, pieceId) => possibleFutures`, where:
  *  `well` is as defined above
  * `pieceId` is any string indicating the name of a piece: 'I', 'J', 'L', 'O', 'T', 'S' or 'Z'
  * the returned `possibleFutures` is an array of all possible future well states which could ensue, taking into account every possible location where the player could land this piece. A single possible future well state is an object `{ well, score }` where:
    *  `well` is again as defined above
    * `score` is the number of lines scored. In most cases `score` will be 0, but it can be 1, 2, 3 or 4.
* the AI's returned `pieceId` is as defined above.

Very simple AIs might ignore the current state of the well or the possible futures:

```js
const iForever = () => 'I'
const sz = () => ['S', 'Z'][Math.floor(Math.rand() * 2)]
```

More advanced AIs might analyse the well to statically determine the best piece to send next. `getPossibleFutures` is provided to make this easier. HATETRIS uses `getPossibleFutures` to find all the possible outcomes for all possible pieces, rank those outcomes to find the best for each piece, and then select the piece with the worst best outcome. Other AIs could plug those possible futures back into `getPossibleFutures` to explore further into the future, or use different heuristics to rank the wells.

This functionality isn't exposed yet, but that should come soon.