### PR TITLE
Store AI state and pass it around

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ A custom AI for HATETRIS should be a **JavaScript [function expression](https://
 // Called every time the game needs to spawn a new piece to provide to the player.
 // In this example, we return a constant stream of 4x1s, unless the well is all set
 // up for a Tetris, in which case we return an S piece
-(currentState, getNextStates) => {
-  const nextStates = getNextStates(currentState, 'I')
-  for (const nextState of nextStates) {
-    if (nextState.score === currentState.score + 4) {
+(currentWellState, currentAiState, getNextWellStates) => {
+  const nextWellStates = getNextWellStates(currentWellState, 'I')
+  for (const nextWellState of nextWellStates) {
+    if (nextWellState.score === currentWellState.score + 4) {
       return 'S'
     }
   }
@@ -23,42 +23,60 @@ A custom AI for HATETRIS should be a **JavaScript [function expression](https://
 }
 ```
 
-This function has the form `(currentState, getNextStates) => nextPieceId`, where:
-
-* `currentState` is the current well state object
-* `getNextStates` is a helper function `(state, pieceId) => nextStates`, where:
-  * `state` can be any **well state object** (see below). You can pass `currentState` here, but you can also create and pass your own hypotheticals
-  * `pieceId` can be any string indicating the name of a piece: "I", "J", "L", "O", "S", "T" or "Z"
-  * the returned `nextStates` is an array of all of the possible new well state objects which could ensue, taking into account every possible location where the player could land this piece
-* the returned `nextPieceId` is the name of the piece the game should spawn now
-
-A well state object has the form `{ well, score }`, where:
+`currentWellState` is the current **well state object**. This has the form `{ well, score }`, where:
 
 * `well` is an array of 20 binary numbers, one representing each row in the well from top to bottom. Each bit in each number represents a cell in that row: 0 if the cell is currently clear, and 1 if it is currently obstructed. (Note: the least significant bit represents the first cell, so if the value is `0b0000000011`, the leftmost two cells in the row are occupied.)
 * `score` is the current score, a non-negative integer.
 
-Very simple AIs might ignore both the current state of the well and the possible next states:
+`currentAiState` is the current **AI state value**. When spawning the very first piece, this value is `undefined`. For later piece spawns, this value is whatever AI state value you returned last time.
+
+`getNextStates` is a helper function `(wellState, pieceId) => nextWellStates`, where:
+
+* `state` can be any well state object. You can pass `currentWellState` here, but you can also create and pass your own hypotheticals.
+* `pieceId` can be any string indicating the name of a piece: "I", "J", "L", "O", "S", "T" or "Z".
+* The returned `nextWellStates` is an array of all of the possible new well state objects which could ensue, taking into account every possible location where the player could land this piece.
+
+The return value from this function should normally be another piece ID, indicating which piece which the game should spawn now.
+
+Alternatively, the return value can be an array `[nextPieceId, nextAiState]`, where:
+
+* `nextPieceId` will be used as the next piece ID.
+* `nextAiState` can be any value. This value will be passed in as `currentAiState` next time your custom AI function is called.
+
+If you return a piece ID by itself, then implicitly the returned value of `nextAiState` is `currentAiState` - that is, the AI state object is left unchanged for the next time your custom AI function is called.
+
+### Well state object
+
+### Examples
+
+Very simple AIs might ignore all arguments and return the same thing every time:
 
 ```js
 () => 'I'
 ```
 
-```js
-() => ['S', 'Z'][Math.floor(Math.rand() * 2)]
-```
-
-More advanced AIs might analyse the current layout of the well to statically determine the best piece to send next:
+A more advanced AI might analyse the current layout of the well to statically determine the best piece to send next:
 
 ```js
-currentState =>
-  currentState.well[currentState.well.length - 1] === 0
+currentWellState =>
+  currentWellState.well[currentWellState.well.length - 1] === 0
     ? 'I' // when the well is empty, send a 4x1
     : 'S' // otherwise S pieces forever
 ```
 
-However, more advanced AIs still will make use of `getNextStates`. This helper function is provided to make it possible to model future possibilities without laboriously reimplementing all of the game's movement code. For example, the default HATETRIS algorithm uses `getNextStates` to find all the possible outcomes for all possible pieces, rank those outcomes to find the best for each piece, and then select the piece with the worst best outcome. Other AIs could, for example, plug those possible futures back into `getNextStates` to explore further into the future, or use different heuristics to rank the wells and decide how to prune the search tree.
+You can use the AI state value to store state between function calls:
 
-Because custom AIs can behave non-deterministically, replays are not available using custom AIs.
+```js
+// Ignore well state. Return S and Z pieces, alternating
+(_, currentAiState) =>
+  currentAiState?.last === 'S'
+    ? ['Z', { last: 'Z' }]
+    : ['S', { last: 'S' }]
+```
+
+More advanced AIs still will make use of `getNextStates`. This helper function is provided to make it possible to model future possibilities without laboriously reimplementing all of the game's movement code. For example, the default HATETRIS algorithm uses `getNextStates` to find all the possible outcomes for all possible pieces, rank those outcomes to find the best for each piece, and then select the piece with the worst best outcome. Other AIs could, for example, plug those possible futures back into `getNextStates` to explore further into the future, or use different heuristics to rank the wells and decide how to prune the search tree.
+
+Because custom AIs can behave non-deterministically, replays are (currently!) not available using custom AIs.
 
 ### Does this use `eval` internally? Isn't there a security risk from that?
 

--- a/src/components/Game/Game.spec.tsx
+++ b/src/components/Game/Game.spec.tsx
@@ -101,6 +101,10 @@ describe('<Game>', () => {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }],
       replay: []
@@ -115,12 +119,20 @@ describe('<Game>', () => {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 2, y: 0 }
       }],
       replay: ['L']
@@ -135,18 +147,30 @@ describe('<Game>', () => {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 2, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }],
       replay: ['L', 'R']
@@ -161,24 +185,40 @@ describe('<Game>', () => {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 2, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 1 }
       }],
       replay: ['L', 'R', 'D']
@@ -193,30 +233,50 @@ describe('<Game>', () => {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 2, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 1 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 1, x: 3, y: 1 }
       }],
       replay: ['L', 'R', 'D', 'U']
@@ -231,30 +291,50 @@ describe('<Game>', () => {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 2, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 1 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 1, x: 3, y: 1 }
       }],
       replay: ['L', 'R', 'D', 'U']
@@ -269,30 +349,50 @@ describe('<Game>', () => {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 2, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 0 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 0, x: 3, y: 1 }
       }, {
         core: {
           well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
           score: 0
         },
+        ai: [{
+          well: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+          pieceIds: ['S']
+        }],
         piece: { id: 'S', o: 1, x: 3, y: 1 }
       }],
       replay: ['L', 'R', 'D', 'U']
@@ -429,6 +529,28 @@ describe('<Game>', () => {
       replayCopiedTimeoutId: undefined,
       replayTimeoutId: undefined
     })
+  })
+
+  it('supports a custom AI with state', () => {
+    const game = getGame()
+
+    game.find('.e2e__select-ai').simulate('click')
+    game.find('.e2e__custom-enemy').simulate('click')
+    game.find('.e2e__ai-textarea').simulate('change', {
+      target: {
+        // AI state is last piece sent
+        // (_, aiState) => aiState === 'S' ? ['Z', 'Z'] : ['S', 'S']
+        value: '(_, aiState) => aiState === \'S\' ? [\'Z\', \'Z\'] : [\'S\', \'S\']'
+      }
+    })
+    game.find('.e2e__submit-custom-enemy').simulate('click')
+    game.find('.e2e__start-button').simulate('click')
+
+    expect(game.state().wellStates[game.state().wellStateId].piece.id).toBe('S')
+    for (let i = 0; i < 18; i++) {
+      game.instance().handleDown()
+    }
+    expect(game.state().wellStates[game.state().wellStateId].piece.id).toBe('Z')
   })
 
   it('lets you decide NOT to use a custom AI', () => {

--- a/src/components/Well/Well.spec.tsx
+++ b/src/components/Well/Well.spec.tsx
@@ -58,6 +58,7 @@ describe('<Well>', () => {
           ],
           score: 31
         },
+        ai: undefined,
         piece: { id: 'S', x: 3, y: 0, o: 0 }
       }
     })).toMatchSnapshot()
@@ -91,6 +92,7 @@ describe('<Well>', () => {
           ],
           score: 31
         },
+        ai: undefined,
         piece: null
       }
     })).toMatchSnapshot()

--- a/src/enemy-ais/hatetris-ai.spec.tsx
+++ b/src/enemy-ais/hatetris-ai.spec.tsx
@@ -364,5 +364,4 @@ describe('hatetrisAi', () => {
       pieceIds: ['S', 'Z', 'O', 'I', 'L', 'J', 'T'] // unchanged
     }]])
   })
-
 })

--- a/src/enemy-ais/hatetris-ai.ts
+++ b/src/enemy-ais/hatetris-ai.ts
@@ -77,26 +77,26 @@ export const hatetrisAi: EnemyAi = (
     pieceId,
     prevIndex === -1
       ? [
-        ...currentAiState,
-        {
-          well: currentCoreState.well,
-          pieceIds: [pieceId]
-        }
-      ]
+          ...currentAiState,
+          {
+            well: currentCoreState.well,
+            pieceIds: [pieceId]
+          }
+        ]
       : currentAiState[prevIndex].pieceIds.includes(pieceId)
         // No duplicates. Approximately 0% probability of this ever happening with this
         // AI, but as a general technique it's worth having this on the books
         ? currentAiState
         : [
-          ...currentAiState.slice(0, prevIndex),
-          {
-            ...currentAiState[prevIndex],
-            pieceIds: [
-              ...currentAiState[prevIndex].pieceIds,
-              pieceId
-            ]
-          },
-          ...currentAiState.slice(prevIndex + 1)
-        ]
+            ...currentAiState.slice(0, prevIndex),
+            {
+              ...currentAiState[prevIndex],
+              pieceIds: [
+                ...currentAiState[prevIndex].pieceIds,
+                pieceId
+              ]
+            },
+            ...currentAiState.slice(prevIndex + 1)
+          ]
   ]
 }


### PR DESCRIPTION
Every frame of the history of every game now also stores the current AI state at that time. This can only ever change on new piece spawns, but given that the AI state value is identical each time, storing it redundantly likely isn't a massive problem here. Who knows, theoretically we might want to add AI behaviour which can change on every keystroke? Haha, just kidding...

Documentation is updated with the new API.