### PR TITLE
Allow whitespace padding in replays; allow `async` AIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the source code for [HATETRIS](https://qntm.org/hatetris).
 
 ## Writing a custom AI
 
-A custom AI for HATETRIS should be a **JavaScript [function expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function)** (or [arrow function expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)), looking something like this:
+A custom AI for HATETRIS should be a possibly-[`async`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) **JavaScript [function expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function)** (or [arrow function expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)), looking something like this:
 
 ```js
 // AI function.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ You can use the AI state value to store state between function calls:
 
 More advanced AIs still will make use of `getNextStates`. This helper function is provided to make it possible to model future possibilities without laboriously reimplementing all of the game's movement code. For example, [the default HATETRIS algorithm](https://github.com/qntm/hatetris/blob/9b683713050a72d12c5bd6ba4657c9237030fa74/src/enemy-ais/hatetris-ai.ts) uses `getNextStates` to find all the possible outcomes for all possible pieces, rank those outcomes to find the best for each piece, and then select the piece with the worst best outcome. Other AIs could, for example, plug those possible futures back into `getNextStates` to explore further into the future, or use different heuristics to rank the wells and decide how to prune the search tree.
 
+An AI may also be asynchronous:
+
+```js
+async currentWellState => {
+  const result = await someLongerCalculationOrCall()
+  return result === true ? 'I' : 'S'
+}
+```
+
 ### Does this use `eval` internally? Isn't there a security risk from that?
 
-Yes, and yes. You are at mortal risk of attacking yourself. Do not paste code into HATETRIS unless you understand every line of it.
+Yes, and yes. You are at mortal risk of attacking yourself. Do not paste code into HATETRIS unless you trust it.

--- a/src/components/Game/Game.spec.tsx
+++ b/src/components/Game/Game.spec.tsx
@@ -1,7 +1,5 @@
 /* eslint-env jest */
 
-'use strict'
-
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/react'
 import * as React from 'react'
@@ -314,6 +312,26 @@ describe('<Game>', () => {
     prompt.mockRestore()
   })
 
+  // The act of initiating a replay causes a timeout to be created which
+  // will play one step of the replay. If we use Jest to wait for that
+  // timeout to trigger, then that'll play back one move... but it will
+  // still leave various promises unresolved. `handleMove` won't return,
+  // which means `handleRedo` won't return, which means the next replay
+  // timeout won't be created. This means we can't just wait for any
+  // amount of time... we need create another promise which will resolve
+  // along with those other unresolved promises...
+  const advanceReplaySteps = async n => {
+    for (let i = 0; i < n; i++) {
+      const promise = new Promise(resolve => {
+        setTimeout(resolve, 0)
+      })
+      await jest.advanceTimersByTime(replayTimeout)
+
+      // ...then `await` THAT
+      await promise
+    }
+  }
+
   it('lets you replay a too-long replay', async () => {
     const originalWarn = console.warn
     const mockWarn = jest.fn()
@@ -330,8 +348,8 @@ describe('<Game>', () => {
     ])
     prompt.mockRestore()
 
-    // Play beyond the end of the supplied replay
-    jest.advanceTimersByTime(replayTimeout * 150)
+    // Play beyond the end of the supplied replay.
+    await advanceReplaySteps(250)
 
     expect(mockWarn.mock.calls).toEqual([
       ['Ignoring input replay step because mode is', 'GAME_OVER']
@@ -353,7 +371,7 @@ describe('<Game>', () => {
     prompt.mockRestore()
 
     // Play beyond the end of the supplied replay
-    jest.advanceTimersByTime(replayTimeout * 30)
+    await advanceReplaySteps(30)
 
     await user.keyboard('{Control>}z{/Control}')
     // TODO: assert that `wellStateId` is now decremented?

--- a/src/components/Game/Game.tsx
+++ b/src/components/Game/Game.tsx
@@ -113,15 +113,15 @@ class Game extends React.Component<GameProps, GameState> {
 
   logic = getLogic(this.props)
 
-  getFirstWellState () {
-    return this.logic.getFirstWellState(this.state)
+  async getFirstWellState () {
+    return await this.logic.getFirstWellState(this.state)
   }
 
-  handleMove (move: string) {
-    this.setState(this.logic.handleMove(this.state, move))
+  async handleMove (move: string) {
+    this.setState(await this.logic.handleMove(this.state, move))
   }
 
-  handleClickStart = () => {
+  handleClickStart = async () => {
     const {
       replayCopiedTimeoutId,
       replayTimeoutId
@@ -134,7 +134,7 @@ class Game extends React.Component<GameProps, GameState> {
 
     let firstWellState: WellState
     try {
-      firstWellState = this.getFirstWellState()
+      firstWellState = await this.getFirstWellState()
     } catch (error) {
       console.error(error)
       this.setState({
@@ -164,7 +164,7 @@ class Game extends React.Component<GameProps, GameState> {
     })
   }
 
-  handleClickReplay = () => {
+  handleClickReplay = async () => {
     const {
       replayTimeout
     } = this.props
@@ -189,7 +189,7 @@ class Game extends React.Component<GameProps, GameState> {
 
     let firstWellState: WellState
     try {
-      firstWellState = this.getFirstWellState()
+      firstWellState = await this.getFirstWellState()
     } catch (error) {
       console.error(error)
       this.setState({
@@ -218,7 +218,7 @@ class Game extends React.Component<GameProps, GameState> {
     })
   }
 
-  handleReplayTimeout = () => {
+  handleReplayTimeout = async () => {
     const {
       replayTimeout
     } = this.props
@@ -232,7 +232,7 @@ class Game extends React.Component<GameProps, GameState> {
     let nextReplayTimeoutId
 
     if (mode === 'REPLAYING') {
-      this.handleRedo()
+      await this.handleRedo()
 
       if (wellStateId + 1 in replay) {
         nextReplayTimeoutId = setTimeout(this.handleReplayTimeout, replayTimeout)
@@ -246,37 +246,37 @@ class Game extends React.Component<GameProps, GameState> {
     })
   }
 
-  handleLeft = () => {
+  handleLeft = async () => {
     const { mode } = this.state
     if (mode === 'PLAYING') {
-      this.handleMove('L')
+      await this.handleMove('L')
     } else {
       console.warn('Ignoring event L because mode is', mode)
     }
   }
 
-  handleRight = () => {
+  handleRight = async () => {
     const { mode } = this.state
     if (mode === 'PLAYING') {
-      this.handleMove('R')
+      await this.handleMove('R')
     } else {
       console.warn('Ignoring event R because mode is', mode)
     }
   }
 
-  handleDown = () => {
+  handleDown = async () => {
     const { mode } = this.state
     if (mode === 'PLAYING') {
-      this.handleMove('D')
+      await this.handleMove('D')
     } else {
       console.warn('Ignoring event D because mode is', mode)
     }
   }
 
-  handleUp = () => {
+  handleUp = async () => {
     const { mode } = this.state
     if (mode === 'PLAYING') {
-      this.handleMove('U')
+      await this.handleMove('U')
     } else {
       console.warn('Ignoring event U because mode is', mode)
     }
@@ -307,7 +307,7 @@ class Game extends React.Component<GameProps, GameState> {
     }
   }
 
-  handleRedo = () => {
+  handleRedo = async () => {
     const {
       mode,
       replay,
@@ -316,7 +316,7 @@ class Game extends React.Component<GameProps, GameState> {
 
     if (mode === 'PLAYING' || mode === 'REPLAYING') {
       if (wellStateId in replay) {
-        this.handleMove(replay[wellStateId])
+        await this.handleMove(replay[wellStateId])
       } else {
         console.warn('Ignoring redo event because end of history has been reached')
       }
@@ -325,21 +325,21 @@ class Game extends React.Component<GameProps, GameState> {
     }
   }
 
-  handleDocumentKeyDown = (event: KeyboardEvent) => {
+  handleDocumentKeyDown = async (event: KeyboardEvent) => {
     if (event.key === 'Left' || event.key === 'ArrowLeft') {
-      this.handleLeft()
+      await this.handleLeft()
     }
 
     if (event.key === 'Right' || event.key === 'ArrowRight') {
-      this.handleRight()
+      await this.handleRight()
     }
 
     if (event.key === 'Down' || event.key === 'ArrowDown') {
-      this.handleDown()
+      await this.handleDown()
     }
 
     if (event.key === 'Up' || event.key === 'ArrowUp') {
-      this.handleUp()
+      await this.handleUp()
     }
 
     if (event.key === 'z' && event.ctrlKey === true) {
@@ -347,7 +347,7 @@ class Game extends React.Component<GameProps, GameState> {
     }
 
     if (event.key === 'y' && event.ctrlKey === true) {
-      this.handleRedo()
+      await this.handleRedo()
     }
   }
 

--- a/src/components/Game/logic.spec.ts
+++ b/src/components/Game/logic.spec.ts
@@ -187,22 +187,22 @@ describe('logic', () => {
                   replayTimeoutId: undefined
                 }
 
-                firstState.wellStates.push(logic.getFirstWellState(firstState))
+                firstState.wellStates.push(await logic.getFirstWellState(firstState))
                 firstState.wellStateId++
 
-                const finalState = replay.reduce(
-                  (state, move) => ({
-                    ...state,
-                    ...(
-                      state.mode === 'GAME_OVER'
-                        ? undefined // ignore the remaining moves
-                        : logic.handleMove(state, move)
-                    )
-                  }),
-                  firstState
-                )
+                let state = firstState
+                for (const move of replay) {
+                  if (state.mode === 'GAME_OVER') {
+                    // ignore the remaining moves
+                  } else {
+                    state = {
+                      ...state,
+                      ...await logic.handleMove(state, move)
+                    }
+                  }
+                }
 
-                expect(finalState.wellStates[finalState.wellStateId].core.score)
+                expect(state.wellStates[state.wellStateId].core.score)
                   .toBe(expectedScore)
               })
             })

--- a/src/enemy-ais/burgiel.spec.tsx
+++ b/src/enemy-ais/burgiel.spec.tsx
@@ -12,8 +12,8 @@ import { burgAi } from './burgiel'
 describe('burgAi', () => {
   const getNextCoreStates = (): CoreState[] => []
 
-  it('generates an S at first', () => {
-    expect(burgAi({
+  it('generates an S at first', async () => {
+    expect(await burgAi({
       score: 0,
       well: [
         0b000000,
@@ -26,8 +26,8 @@ describe('burgAi', () => {
     }, undefined, getNextCoreStates)).toEqual(['S', 'Z'])
   })
 
-  it('generates a Z next', () => {
-    expect(burgAi({
+  it('generates a Z next', async () => {
+    expect(await burgAi({
       score: 0,
       well: [
         0b000000,
@@ -40,8 +40,8 @@ describe('burgAi', () => {
     }, 'Z', getNextCoreStates)).toEqual(['Z', 'S'])
   })
 
-  it('generates an S after that', () => {
-    expect(burgAi({
+  it('generates an S after that', async () => {
+    expect(await burgAi({
       score: 0,
       well: [
         0b000000,

--- a/src/enemy-ais/hatetris-ai.spec.tsx
+++ b/src/enemy-ais/hatetris-ai.spec.tsx
@@ -19,7 +19,7 @@ const logic = getLogic({
 const getNextCoreStates = logic.getNextCoreStates
 
 describe('hatetrisAi', () => {
-  it('generates an S by default', () => {
+  it('generates an S by default', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -30,7 +30,7 @@ describe('hatetrisAi', () => {
       0b0000000000,
       0b0000000000
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, undefined, getNextCoreStates)).toEqual(['S', new Set([
@@ -38,7 +38,7 @@ describe('hatetrisAi', () => {
     ])])
   })
 
-  it('generates a Z when an S would result in a lower stack', () => {
+  it('generates a Z when an S would result in a lower stack', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -49,7 +49,7 @@ describe('hatetrisAi', () => {
       0b0001000000,
       0b1111011111
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, undefined, getNextCoreStates)).toEqual(['Z', new Set([
@@ -57,7 +57,7 @@ describe('hatetrisAi', () => {
     ])])
   })
 
-  it('generates an O when an S or Z would result in a lower stack', () => {
+  it('generates an O when an S or Z would result in a lower stack', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -68,7 +68,7 @@ describe('hatetrisAi', () => {
       0b0000000000,
       0b1111101111
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, undefined, getNextCoreStates)).toEqual(['O', new Set([
@@ -76,7 +76,7 @@ describe('hatetrisAi', () => {
     ])])
   })
 
-  it('generates an I when an S, Z or O would result in a lower stack', () => {
+  it('generates an I when an S, Z or O would result in a lower stack', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -87,7 +87,7 @@ describe('hatetrisAi', () => {
       0b0000000000,
       0b1111001111
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, undefined, getNextCoreStates)).toEqual(['I', new Set([
@@ -95,7 +95,7 @@ describe('hatetrisAi', () => {
     ])])
   })
 
-  it('generates an L when an S, Z, O or I would result in a lower stack', () => {
+  it('generates an L when an S, Z, O or I would result in a lower stack', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -106,7 +106,7 @@ describe('hatetrisAi', () => {
       0b1011100111,
       0b1111110111
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, undefined, getNextCoreStates)).toEqual(['L', new Set([
@@ -114,7 +114,7 @@ describe('hatetrisAi', () => {
     ])])
   })
 
-  it('generates a J when an S, Z, O, I or L would result in a lower stack', () => {
+  it('generates a J when an S, Z, O, I or L would result in a lower stack', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -125,7 +125,7 @@ describe('hatetrisAi', () => {
       0b1011100111,
       0b1111101111
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, undefined, getNextCoreStates)).toEqual(['J', new Set([
@@ -133,7 +133,7 @@ describe('hatetrisAi', () => {
     ])])
   })
 
-  it('generates a T when an S, Z, O, I, L or J would result in a lower stack', () => {
+  it('generates a T when an S, Z, O, I, L or J would result in a lower stack', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -144,7 +144,7 @@ describe('hatetrisAi', () => {
       0b1111000011,
       0b1111100111
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, undefined, getNextCoreStates)).toEqual(['T', new Set([
@@ -157,7 +157,7 @@ describe('hatetrisAi', () => {
   // height*. In this situation, L, J and T would all result in a stack
   // reaching y = 6. L comes first so it is selected. This happens even though
   // L and J *give you a line* while T would not.
-  it('just gives you a line sometimes!', () => {
+  it('just gives you a line sometimes!', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -168,7 +168,7 @@ describe('hatetrisAi', () => {
       0b1111000011,
       0b1111100111
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, undefined, getNextCoreStates)).toEqual(['L', new Set([
@@ -177,7 +177,7 @@ describe('hatetrisAi', () => {
   })
 
   // Coverage...
-  it('generates an S when say an I would clear the board', () => {
+  it('generates an S when say an I would clear the board', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -188,7 +188,7 @@ describe('hatetrisAi', () => {
       0b1111111110,
       0b1111111110
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, undefined, getNextCoreStates)).toEqual(['S', new Set([
@@ -197,7 +197,7 @@ describe('hatetrisAi', () => {
   })
 
   // Loop avoidance
-  it('generates a Z if it already generated an S once', () => {
+  it('generates a Z if it already generated an S once', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -208,7 +208,7 @@ describe('hatetrisAi', () => {
       0b0001000000,
       0b0011100000
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, new Set([
@@ -237,7 +237,7 @@ describe('hatetrisAi', () => {
     ])])
   })
 
-  it('gives up and generates an S if EVERY piece leads into a cycle', () => {
+  it('gives up and generates an S if EVERY piece leads into a cycle', async () => {
     const well = [
       0b0000000000,
       0b0000000000,
@@ -248,7 +248,7 @@ describe('hatetrisAi', () => {
       0b0000000000,
       0b0000000000
     ]
-    expect(hatetrisAi({
+    expect(await hatetrisAi({
       score: 0,
       well
     }, new Set([

--- a/src/enemy-ais/lovetris-ai.spec.tsx
+++ b/src/enemy-ais/lovetris-ai.spec.tsx
@@ -19,8 +19,8 @@ const logic = getLogic({
 const getNextCoreStates = logic.getNextCoreStates
 
 describe('lovetrisAi', () => {
-  it('generates I every time right now', () => {
-    expect(lovetrisAi({
+  it('generates I every time right now', async () => {
+    expect(await lovetrisAi({
       score: 0,
       well: [
         0b0000000000,

--- a/src/enemy-ais/lovetris-ai.ts
+++ b/src/enemy-ais/lovetris-ai.ts
@@ -1,5 +1,5 @@
-'use strict'
+// Just for the sake of example, make this async
 
 import type { EnemyAi } from '../components/Game/Game.jsx'
 
-export const lovetrisAi: EnemyAi = () => 'I'
+export const lovetrisAi: EnemyAi = async () => 'I'

--- a/src/replay-codecs/hatetris-replay-codec.spec.ts
+++ b/src/replay-codecs/hatetris-replay-codec.spec.ts
@@ -13,6 +13,12 @@ describe('hatetrisReplayCodec', () => {
     expect(hatetrisReplayCodec.decode('ਹԇ')).toEqual(['D', 'D', 'D', 'R', 'U', 'D'])
   })
 
+  it('decodes with spaces', () => {
+    expect(hatetrisReplayCodec.decode(' A9E')).toEqual(['D', 'D', 'D', 'R', 'U', 'D'])
+    expect(hatetrisReplayCodec.decode('𤺤 ')).toEqual(['D', 'D', 'D', 'R', 'U', 'D'])
+    expect(hatetrisReplayCodec.decode(' ਹԇ ')).toEqual(['D', 'D', 'D', 'R', 'U', 'D'])
+  })
+
   // Due to padding, a replay (which always ends with a "D" instruction) sometimes has an
   // additional trailing "L" or "D"
   describe('known replays', () => {

--- a/src/replay-codecs/hatetris-replay-codec.ts
+++ b/src/replay-codecs/hatetris-replay-codec.ts
@@ -2,8 +2,6 @@
   Replay handling. This codec is a combination of three other codecs
 */
 
-'use strict'
-
 import hex from './hex'
 import * as base65536 from './base65536'
 import * as base2048 from './base2048'
@@ -19,6 +17,8 @@ const encode = (moves: string[]): string => base2048.encode(moves)
   Convert a string back into an array of moves
 */
 const decode = (string: string): string[] => {
+  string = string.trim()
+
   if (/^[0123456789ABCDEF# ]*$/.test(string)) {
     return hex.decode(string)
   }


### PR DESCRIPTION
* Leading and trailing whitespace is now stripped from replay input. This is important for Base65536 and Base2048 replays. Fixes #79.
* AIs may now be `async`. This meant quite a lot of `logic.ts` became `async` too, which had knock-on effects in `<Game>`, which in turn made testing replay behaviour a little annoying. Part of #67.