### PR TITLE
Favour rarely-seen wells

### DIFF
--- a/src/enemy-ais/hatetris-ai.spec.tsx
+++ b/src/enemy-ais/hatetris-ai.spec.tsx
@@ -33,9 +33,9 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, undefined, getNextCoreStates)).toEqual(['S', new Set([
-      JSON.stringify(well)
-    ])])
+    }, undefined, getNextCoreStates)).toEqual(['S', {
+      [JSON.stringify(well)]: 1
+    }])
   })
 
   it('generates a Z when an S would result in a lower stack', async () => {
@@ -52,9 +52,9 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, undefined, getNextCoreStates)).toEqual(['Z', new Set([
-      JSON.stringify(well)
-    ])])
+    }, undefined, getNextCoreStates)).toEqual(['Z', {
+      [JSON.stringify(well)]: 1
+    }])
   })
 
   it('generates an O when an S or Z would result in a lower stack', async () => {
@@ -71,9 +71,9 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, undefined, getNextCoreStates)).toEqual(['O', new Set([
-      JSON.stringify(well)
-    ])])
+    }, undefined, getNextCoreStates)).toEqual(['O', {
+      [JSON.stringify(well)]: 1
+    }])
   })
 
   it('generates an I when an S, Z or O would result in a lower stack', async () => {
@@ -90,9 +90,9 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, undefined, getNextCoreStates)).toEqual(['I', new Set([
-      JSON.stringify(well)
-    ])])
+    }, undefined, getNextCoreStates)).toEqual(['I', {
+      [JSON.stringify(well)]: 1
+    }])
   })
 
   it('generates an L when an S, Z, O or I would result in a lower stack', async () => {
@@ -109,9 +109,9 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, undefined, getNextCoreStates)).toEqual(['L', new Set([
-      JSON.stringify(well)
-    ])])
+    }, undefined, getNextCoreStates)).toEqual(['L', {
+      [JSON.stringify(well)]: 1
+    }])
   })
 
   it('generates a J when an S, Z, O, I or L would result in a lower stack', async () => {
@@ -128,9 +128,9 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, undefined, getNextCoreStates)).toEqual(['J', new Set([
-      JSON.stringify(well)
-    ])])
+    }, undefined, getNextCoreStates)).toEqual(['J', {
+      [JSON.stringify(well)]: 1
+    }])
   })
 
   it('generates a T when an S, Z, O, I, L or J would result in a lower stack', async () => {
@@ -147,9 +147,9 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, undefined, getNextCoreStates)).toEqual(['T', new Set([
-      JSON.stringify(well)
-    ])])
+    }, undefined, getNextCoreStates)).toEqual(['T', {
+      [JSON.stringify(well)]: 1
+    }])
   })
 
   // Only while writing these unit tests did I discover this subtle piece of
@@ -171,9 +171,9 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, undefined, getNextCoreStates)).toEqual(['L', new Set([
-      JSON.stringify(well)
-    ])])
+    }, undefined, getNextCoreStates)).toEqual(['L', {
+      [JSON.stringify(well)]: 1
+    }])
   })
 
   // Coverage...
@@ -191,9 +191,9 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, undefined, getNextCoreStates)).toEqual(['S', new Set([
-      JSON.stringify(well)
-    ])])
+    }, undefined, getNextCoreStates)).toEqual(['S', {
+      [JSON.stringify(well)]: 1
+    }])
   })
 
   // Loop avoidance
@@ -211,8 +211,8 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, new Set([
-      JSON.stringify([
+    }, {
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -221,9 +221,9 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0001000110, // an S was landed here
         0b0011100011
-      ])
-    ]), getNextCoreStates)).toEqual(['Z', new Set([
-      JSON.stringify([
+      ])]: 1
+    }, getNextCoreStates)).toEqual(['Z', {
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -232,9 +232,9 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0001000110,
         0b0011100011
-      ]),
-      JSON.stringify(well)
-    ])])
+      ])]: 1,
+      [JSON.stringify(well)]: 1
+    }])
   })
 
   it('gives up and generates an S if EVERY piece leads into a cycle', async () => {
@@ -251,8 +251,8 @@ describe('hatetrisAi', () => {
     expect(await hatetrisAi({
       score: 0,
       well
-    }, new Set([
-      JSON.stringify([
+    }, {
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -261,8 +261,8 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000000,
         0b0000001111 // an I was landed
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -271,8 +271,8 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000011,
         0b0000000011 // an O was landed
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -281,8 +281,8 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000001,
         0b0000000111 // a J was landed
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -291,8 +291,8 @@ describe('hatetrisAi', () => {
         0b0000000001,
         0b0000000001,
         0b0000000011 // an L was landed
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -301,8 +301,8 @@ describe('hatetrisAi', () => {
         0b0000000001,
         0b0000000011,
         0b0000000010 // an S was landed
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -311,8 +311,8 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000011,
         0b0000000110 // a Z was landed
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -321,9 +321,9 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000010,
         0b0000000111 // a T was landed
-      ])
-    ]), getNextCoreStates)).toEqual(['S', new Set([
-      JSON.stringify([
+      ])]: 1
+    }, getNextCoreStates)).toEqual(['S', {
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -332,8 +332,8 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000000,
         0b0000001111
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -342,8 +342,8 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000011,
         0b0000000011
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -352,8 +352,8 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000001,
         0b0000000111
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -362,8 +362,8 @@ describe('hatetrisAi', () => {
         0b0000000001,
         0b0000000001,
         0b0000000011
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -372,8 +372,8 @@ describe('hatetrisAi', () => {
         0b0000000001,
         0b0000000011,
         0b0000000010
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -382,8 +382,8 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000011,
         0b0000000110
-      ]),
-      JSON.stringify([
+      ])]: 1,
+      [JSON.stringify([
         0b0000000000,
         0b0000000000,
         0b0000000000,
@@ -392,8 +392,189 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000010,
         0b0000000111
-      ]),
-      JSON.stringify(well)
-    ])])
+      ])]: 1,
+      [JSON.stringify(well)]: 1
+    }])
+  })
+
+  it('spawns the piece which leads into the fewest cycles', async () => {
+    const well = [
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000,
+      0b0000000000
+    ]
+    expect(await hatetrisAi({
+      score: 0,
+      well
+    }, {
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000001111 // an I was landed
+      ])]: 5,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000011,
+        0b0000000011 // an O was landed
+      ])]: 5,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000001,
+        0b0000000111 // a J was landed
+      ])]: 5,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000001,
+        0b0000000001,
+        0b0000000011 // an L was landed
+      ])]: 5,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000001,
+        0b0000000011,
+        0b0000000010 // an S was landed
+      ])]: 5,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000011,
+        0b0000000110 // a Z was landed
+      ])]: 3,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000001100,
+        0b0000011000 // a Z was landed (different), 
+      ])]: 5, // `maxLoops` for Z will be 5, not 3
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000010,
+        0b0000000111 // a T was landed
+      ])]: 3,
+      [JSON.stringify(well)]: 1 // already seen this well once!
+    }, getNextCoreStates)).toEqual(['T', {
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000001111 // an I was landed
+      ])]: 5,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000011,
+        0b0000000011 // an O was landed
+      ])]: 5,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000001,
+        0b0000000111 // a J was landed
+      ])]: 5,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000001,
+        0b0000000001,
+        0b0000000011 // an L was landed
+      ])]: 5,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000001,
+        0b0000000011,
+        0b0000000010 // an S was landed
+      ])]: 5,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000011,
+        0b0000000110 // a Z was landed
+      ])]: 3,
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000001100,
+        0b0000011000 // a Z was landed (different), 
+      ])]: 5, // `maxLoops` for Z will be 5, not 3
+      [JSON.stringify([
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000000,
+        0b0000000010,
+        0b0000000111 // a T was landed
+      ])]: 3,
+      [JSON.stringify(well)]: 2
+    }])
   })
 })

--- a/src/enemy-ais/hatetris-ai.spec.tsx
+++ b/src/enemy-ais/hatetris-ai.spec.tsx
@@ -480,7 +480,7 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000000,
         0b0000001100,
-        0b0000011000 // a Z was landed (different), 
+        0b0000011000 // a Z was landed (different)
       ])]: 5, // `maxLoops` for Z will be 5, not 3
       [JSON.stringify([
         0b0000000000,
@@ -562,7 +562,7 @@ describe('hatetrisAi', () => {
         0b0000000000,
         0b0000000000,
         0b0000001100,
-        0b0000011000 // a Z was landed (different), 
+        0b0000011000 // a Z was landed (different)
       ])]: 5, // `maxLoops` for Z will be 5, not 3
       [JSON.stringify([
         0b0000000000,


### PR DESCRIPTION
This is a minor alteration to the behaviour of the HATETRIS AI. This change is intended to mitigate an extremely unlikely potential future scenario where an attacker has found a "seven-fold loop", where, from the current well, *any* provided piece can be placed in such a way as to lead to a repeat well.

**Previously**, HATETRIS' behaviour in this scenario was to treat "previously seen well" and "previously unseen well" as a binary. Either a piece leads to a previously seen well or it doesn't.

* If none of the pieces leads into a previously seen well, that's a tie, and we revert back to the usual height-checking logic.
* If one of the pieces leads into a previously seen well, we choose one of the other six.
* If six of the pieces lead into previously seen wells, we choose the seventh.
* And, if all seven pieces lead into previously seen wells, the fabled seven-fold loop... well, that's a tie once again, and we revert back to the usual height-checking logic.

But what if we count how many times each well was seen? What if Z, O, I, J, L and T can all lead into a well which has been seen only once, but S can lead into a well which has previously been seen 19 times? With the older logic, HATETRIS considers all seven pieces to be tied, and with nothing else to break the tie, returns an S. This most likely leads into a 20th repeat of that one well. This would indicate a true loop, and a busted algorithm.

With the **new logic**, HATETRIS keeps count of how many times each well has been seen, and uses the number of times seen to break the tie. In this example scenario, HATETRIS would now return a Z.

Per my unit tests, this change preserves existing behaviour for all known scenarios and existing replays. I think this tie-breaking logic is exceedingly unlikely to ever be exercised in practice, although I have added a rigged unit test for it.

I believe that this change means that HATETRIS, if played for long enough, ultimately either (1) kills you, or (2) demonstrates every single possible piece sequence, which, per Brzustowski, kills you. This makes the HATETRIS algorithm **provably undefeatable** (I think), a property it previously conspicuously lacked.